### PR TITLE
Fix: Ensure projetos.js is loaded in projetos.html

### DIFF
--- a/projetos.html
+++ b/projetos.html
@@ -281,6 +281,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <!-- JS Customizado -->
     <script src="./js/data.js"></script>
+    <script src="./js/projetos.js"></script>
     <script src="./js/script.js"></script>
     </script>
     <script


### PR DESCRIPTION
The `projetos.html` page was not loading the `js/projetos.js` script, which is responsible for rendering your projects. This commit adds the necessary script tag to `projetos.html` so that the projects are loaded and displayed correctly.